### PR TITLE
pass query from the request along to each check

### DIFF
--- a/lib/healthcheck/application.rb
+++ b/lib/healthcheck/application.rb
@@ -25,7 +25,7 @@ module Healthcheck
 
     def report_from_request(request)
       checks = filter_checks(Healthcheck.configuration.checks, request.GET)
-      Healthcheck::Report.new(checks)
+      Healthcheck::Report.new(checks, request.GET)
     end
 
     def filter_checks(checks, query)

--- a/lib/healthcheck/checks/abstract_check.rb
+++ b/lib/healthcheck/checks/abstract_check.rb
@@ -24,12 +24,15 @@ module Healthcheck
 
       def reset
         remove_instance_variable(:@result) if @result
+        filter_by_query({})
         true
       end
 
       def self.slug
         name.to_s.demodulize.underscore.to_sym
       end
+
+      def filter_by_query(query); end
 
       private
 

--- a/lib/healthcheck/report.rb
+++ b/lib/healthcheck/report.rb
@@ -35,7 +35,7 @@ module Healthcheck
       end.tap do |c|
         c.reset
         c.paused = paused_data[c.class.slug]
-        c.filter_by_query(query) unless query.nil?
+        c.filter_by_query(query) unless query.present?
       end
     end
 

--- a/lib/healthcheck/report.rb
+++ b/lib/healthcheck/report.rb
@@ -8,8 +8,8 @@ module Healthcheck
   class Report
     attr_reader :checks
 
-    def initialize(checks = Healthcheck.configuration.checks)
-      @checks = checks.map { |check| initialize_check(check) }
+    def initialize(checks = Healthcheck.configuration.checks, query = nil)
+      @checks = checks.map { |check| initialize_check(check, query) }
                       .index_by(&:slug)
     end
 
@@ -27,7 +27,7 @@ module Healthcheck
 
     private
 
-    def initialize_check(check)
+    def initialize_check(check, query)
       case check
       when Healthcheck::Checks::AbstractCheck then check
       when Class then check.new
@@ -35,6 +35,7 @@ module Healthcheck
       end.tap do |c|
         c.reset
         c.paused = paused_data[c.class.slug]
+        c.filter_by_query(query) unless query.nil?
       end
     end
 


### PR DESCRIPTION
An individual check may want to implement an additional filter.
This allows for the get parameters to be passed to the check so
it may further filter down what all that check, checks.