### PR TITLE
transform_values is now native in ruby 2.5+

### DIFF
--- a/lib/healthcheck/report.rb
+++ b/lib/healthcheck/report.rb
@@ -2,7 +2,6 @@ require 'healthcheck'
 require 'json'
 require 'active_support/inflector'
 require 'active_support/core_ext/enumerable'
-require 'active_support/core_ext/hash/transform_values'
 
 module Healthcheck
   class Report


### PR DESCRIPTION
While tinkering around with rails upgrade, found errors around transform_values. Since this is now native in Ruby 2.5+ we no longer need this import from active_support (and it's not available in later versions of active_support) 